### PR TITLE
Camera permissions

### DIFF
--- a/materialbarcodescanner/src/main/java/com/edwardvanraak/materialbarcodescanner/MaterialBarcodeScannerFragment.java
+++ b/materialbarcodescanner/src/main/java/com/edwardvanraak/materialbarcodescanner/MaterialBarcodeScannerFragment.java
@@ -1,7 +1,6 @@
 package com.edwardvanraak.materialbarcodescanner;
 
 import android.Manifest;
-import android.app.Dialog;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -52,7 +51,6 @@ public class MaterialBarcodeScannerFragment extends Fragment {
     protected boolean detectionConsumed;
     private boolean flashOn;
     private int layout;
-    private Dialog dialog;
 
 
     public MaterialBarcodeScannerFragment() {

--- a/materialbarcodescanner/src/main/java/com/edwardvanraak/materialbarcodescanner/MaterialBarcodeScannerFragment.java
+++ b/materialbarcodescanner/src/main/java/com/edwardvanraak/materialbarcodescanner/MaterialBarcodeScannerFragment.java
@@ -142,7 +142,7 @@ public class MaterialBarcodeScannerFragment extends Fragment {
     }
 
     protected void displayCameraPermissionDeniedMessage() {
-        Toast.makeText(getActivity(), "Camera permission required to scan codes!", Toast.LENGTH_LONG).show();
+        Toast.makeText(getActivity(), R.string.default_camera_permission_denied_message, Toast.LENGTH_LONG).show();
     }
 
     // privates

--- a/materialbarcodescanner/src/main/res/values/strings.xml
+++ b/materialbarcodescanner/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="no_camera_permission">Cannot start the barcode reader because the camera permission was not granted.</string>
     <string name="flash_icon">flash icon</string>
     <string name="barcode_square">barcode square</string>
+    <string name="default_camera_permission_denied_message">Camera permission required to scan codes!</string>
 </resources>


### PR DESCRIPTION
This PR updates the Scanner Fragment to handle camera permission requests on its own.

Steps to test:
1. Build the other PRs in this chain (in tru-dl and trusona app)
2. Remove camera permissions from the trusona app if it already had or do a clean install.
3. Go the executive upgrade scanner or the ex trusonafication scanner.
4. Ensure the OS permission dialog shows up.
5. Ensure accepting the permission starts the scanner.
