### PR TITLE
Fixes a cyclic dependency bug in the styles.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar" >
+            android:theme="@style/NoActionBar" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,8 +1,8 @@
 <resources>>
-            <style name="AppTheme.NoActionBar">
-            <item name="windowActionBar">false</item>
-            <item name="windowNoTitle">true</item>
-            <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-            <item name="android:statusBarColor">@android:color/transparent</item>
-        </style>
+    <style name="NoActionBar" parent="AppTheme">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -7,7 +7,7 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
     </style>
-    <style name="AppTheme.NoActionBar">
+    <style name="NoActionBar" parent="AppTheme">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>

--- a/materialbarcodescanner/src/main/AndroidManifest.xml
+++ b/materialbarcodescanner/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
             android:name="com.google.android.gms.vision.DEPENDENCIES"
             android:value="barcode" />
         <activity
-            android:theme="@style/AppTheme.NoActionBar"
+            android:theme="@style/NoActionBar"
             android:name=".MaterialBarcodeScannerActivity"
             android:label="@string/library_name" >
         </activity>

--- a/materialbarcodescanner/src/main/res/values/styles.xml
+++ b/materialbarcodescanner/src/main/res/values/styles.xml
@@ -1,9 +1,9 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="AppTheme.NoActionBar"/>
+    <style name="AppTheme"/>
 
-    <style name="AppTheme.NoActionBar">
+    <style name="NoActionBar" parent="AppTheme">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>


### PR DESCRIPTION
This PR fixes a cyclic dependency bug in the styles of the project.

Steps to test:

1. Go to the project's root folder in a terminal.
2. Execute: `./sbin/builder.sh`
3. Ensure the following error does not appear during the build process: 
```
> Task :app:lintVitalRelease
MaterialBarcodeScanner/app/src/main/res/values/styles.xml:4: 
Error: Style Resource definition cycle: AppTheme => AppTheme.NoActionBar => AppTheme [ResourceCycle]
    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

/MaterialBarcodeScanner/app/src/main/res/values/styles.xml:10: Reference from @style/AppTheme.NoActionBar to style/AppTheme here

   Explanation for issues of type "ResourceCycle":
   There should be no cycles in resource definitions as this can lead to
   runtime exceptions.

```